### PR TITLE
err 1.7.1 fails to install unless xmpppy 0.5.0rc1 is installed

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@needle.com'
 license          'Apache 2.0'
 description      'Installs/Configures err pluggable chat bot'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.1.1'
 
 depends 'git'
 depends 'python'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,6 +48,11 @@ python_virtualenv err_virtualenv do
   action :create
 end
 
+python_pip "xmpppy" do
+  version "0.5.0rc1"
+  virtualenv err_virtualenv
+end
+
 python_pip "err" do
   version node['err']['version']
   virtualenv err_virtualenv


### PR DESCRIPTION
The cookbook in its default state is broken due to err 1.71, which depends on xmppy, however without forcing 0.5.0rc1, the pip install fails.. While this is sort of a hack since there are newer versions of err, the 2.x.x also fail. See: https://github.com/gbin/err/issues/179
